### PR TITLE
fix: support http protocol for custom OpenAI api url

### DIFF
--- a/package.json
+++ b/package.json
@@ -686,12 +686,20 @@
       "default": ""
     },
     {
-      "title": "OpenAI API URL",
-      "name": "openAIAPIURL",
+      "title": "OpenAI Endpoint",
+      "name": "openAIEndpoint",
       "type": "textfield",
       "required": false,
-      "description": "Your OpenAI API URL",
+      "description": "Your OpenAI Endpoint",
       "default": "https://api.openai.com/v1/chat/completions"
+    },
+    {
+      "title": "OpenAI Model",
+      "name": "openAIModel",
+      "type": "textfield",
+      "required": false,
+      "description": "OpenAI Model",
+      "default": "gpt-3.5-turbo"
     },
     {
       "title": "DeepL Auth Key",

--- a/src/axiosConfig.ts
+++ b/src/axiosConfig.ts
@@ -11,7 +11,7 @@
 import { LocalStorage, showToast, Toast } from "@raycast/api";
 import axios from "axios";
 import EventEmitter from "events";
-import { HttpsProxyAgent } from "hpagent";
+import { HttpProxyAgent, HttpsProxyAgent } from "hpagent";
 import { getMacSystemProxy } from "mac-system-proxy";
 import { networkTimeout } from "./consts";
 
@@ -28,6 +28,7 @@ configDefaultAxios();
 export const requestCostTime = "requestCostTime";
 
 export let httpsAgent: HttpsProxyAgent | undefined;
+export let httpAgent: HttpProxyAgent | undefined;
 
 /**
  * Becacuse get system proxy will block 0.4s, we need to get it after finish query.
@@ -184,12 +185,15 @@ export function getSystemProxyURL(): Promise<string | undefined> {
  *
  * * Note: this function will block ~0.4s, so should call it at the right time.
  */
-export function getProxyAgent(): Promise<HttpsProxyAgent | undefined> {
+export function getProxyAgent(isHttps: boolean = true): Promise<HttpsProxyAgent | HttpProxyAgent | undefined> {
   console.log(`---> start getProxyAgent`);
 
-  if (httpsAgent) {
+  if (isHttps && httpsAgent) {
     console.log(`---> return cached httpsAgent`);
     return Promise.resolve(httpsAgent);
+  } else if (!isHttps && httpAgent) {
+    console.log(`---> return cached httpAgent`);
+    return Promise.resolve(httpAgent);
   }
 
   return new Promise((resolve) => {
@@ -203,17 +207,27 @@ export function getProxyAgent(): Promise<HttpsProxyAgent | undefined> {
         }
 
         console.log(`---> get system proxy url: ${systemProxyURL}`);
-        const agent = new HttpsProxyAgent({
-          keepAlive: true,
-          proxy: systemProxyURL,
-        });
-
-        httpsAgent = agent;
-        resolve(agent);
+        if (isHttps) {
+          httpsAgent = new HttpsProxyAgent({
+            keepAlive: true,
+            proxy: systemProxyURL,
+          });
+          resolve(httpsAgent);
+        } else {
+          httpAgent = new HttpProxyAgent({
+            keepAlive: true,
+            proxy: systemProxyURL,
+          });
+          resolve(httpAgent);
+        }
       })
       .catch((error) => {
         console.error(`---> get system proxy url error: ${error}`);
-        httpsAgent = undefined;
+        if (isHttps) {
+          httpsAgent = undefined;
+        } else {
+          httpAgent = undefined;
+        }
         resolve(undefined);
       });
   });

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -64,7 +64,8 @@ export interface MyPreferences {
 
   enableOpenAITranslate: boolean;
   openAIAPIKey: string;
-  openAIAPIURL: string;
+  openAIEndpoint: string;
+  openAIModel: string;
 }
 
 /**
@@ -100,9 +101,9 @@ export class AppKeyStore {
   static volcanoSecretId = myPreferences.volcanoAccessKeyId.trim();
   static volcanoSecretKey = myPreferences.volcanoAccessKeySecret.trim();
 
-  private static defaultOpenAIAPIURL = "https://api.openai.com/v1/chat/completions";
   static openAIAPIKey = myPreferences.openAIAPIKey.trim();
-  static openAIAPIURL = myPreferences.openAIAPIURL.trim() || this.defaultOpenAIAPIURL;
+  static openAIEndpoint = myPreferences.openAIEndpoint.trim() || "https://api.openai.com/v1/chat/completions";
+  static openAIModel = myPreferences.openAIModel.trim() || "gpt-3.5-turbo";
 }
 
 // Test AES online: https://www.sojson.com/encrypt_aes.html

--- a/src/translation/openAI/chat.ts
+++ b/src/translation/openAI/chat.ts
@@ -25,7 +25,7 @@ const timeout = setTimeout(() => {
 export async function requestOpenAIStreamTranslate(queryWordInfo: QueryWordInfo): Promise<QueryTypeResult> {
   console.warn(`---> start request OpenAI`);
 
-  const url = AppKeyStore.openAIAPIURL;
+  const url = AppKeyStore.openAIEndpoint;
 
   const prompt = `translate the following ${queryWordInfo.fromLanguage} text to ${queryWordInfo.toLanguage}, :\n\n${queryWordInfo.word} `;
   console.warn(`---> prompt: ${prompt}`);
@@ -42,7 +42,7 @@ export async function requestOpenAIStreamTranslate(queryWordInfo: QueryWordInfo)
   ];
 
   const params = {
-    model: "gpt-3.5-turbo",
+    model: AppKeyStore.openAIModel,
     messages: message,
     temperature: 0,
     max_tokens: 2000,
@@ -173,7 +173,7 @@ export async function requestOpenAIStreamTranslate(queryWordInfo: QueryWordInfo)
 export function requestOpenAITextTranslate(queryWordInfo: QueryWordInfo): Promise<QueryTypeResult> {
   //   console.warn(`---> start request OpenAI`);
 
-  const url = AppKeyStore.openAIAPIURL;
+  const url = AppKeyStore.openAIEndpoint;
   //   const prompt = `translate from English to Chinese:\n\n"No level of alcohol consumption is safe for our health." =>`;
   const prompt = `translate from ${queryWordInfo.fromLanguage} to ${queryWordInfo.toLanguage}:\n\n"${queryWordInfo.word}" =>`;
   const message = [

--- a/src/translation/openAI/chat.ts
+++ b/src/translation/openAI/chat.ts
@@ -67,6 +67,14 @@ export async function requestOpenAIStreamTranslate(queryWordInfo: QueryWordInfo)
   let openAIResult: QueryTypeResult;
 
   const httpsAgent = await getProxyAgent();
+  const httpAgent = await getProxyAgent(false);
+  const agent = function (url: URL) {
+    if (url.protocol === "http:") {
+      return httpAgent;
+    } else {
+      return httpsAgent;
+    }
+  };
   console.warn(`---> openai agent: ${JSON.stringify(httpsAgent)}`);
 
   return new Promise((resolve, reject) => {
@@ -74,7 +82,7 @@ export async function requestOpenAIStreamTranslate(queryWordInfo: QueryWordInfo)
       method: "POST",
       headers,
       body: JSON.stringify(params),
-      agent: httpsAgent,
+      agent: agent,
       signal: controller.signal,
       onMessage: (msg) => {
         // console.warn(`---> openai msg: ${JSON.stringify(msg)}`);


### PR DESCRIPTION
Users might want to deploy OpenAI API service locally, in which case the HTTP protocol is usually used. But currently setting the http url will cause an error when calling the api. `TypeError [ERR_INVALID_PROTOCOL]: Protocol "http:" not supported. Expected "https:"`

This PR aims to fix this issue.

