### PR TITLE
fix: ignore first inputChange event, fix for #62

### DIFF
--- a/src/easydict.tsx
+++ b/src/easydict.tsx
@@ -234,7 +234,7 @@ export default function (props: LaunchProps<{ arguments: EasydictArguments }>) {
   function onInputChange(text: string) {
     // console.warn(`onInputChange: ${text}`);
 
-    // ignore the first inputChange event to avoid lost queryText argument
+    // Ignore the first inputChange event to avoid lost queryText argument, fix https://github.com/tisfeng/Raycast-Easydict/issues/62
     if (!isInputChanged) {
       setInputChangedState(true);
       console.log("ignore first inputChange event");


### PR DESCRIPTION
Close https://github.com/tisfeng/Raycast-Easydict/issues/62

首次触发的 `onInputChange` 是空字符串，会导致丢失 argument 传进来的 queryText，加了一个 `isInputChanged` 来判断是否是第一次