### PR TITLE
Fix Youdao Translate Error: 50

### DIFF
--- a/src/dictionary/youdao/youdao.ts
+++ b/src/dictionary/youdao/youdao.ts
@@ -220,7 +220,7 @@ export async function requestYoudaoWebTranslate(
   const bv = md5(userAgent);
   const sign = md5("fanyideskweb" + word + salt + "Ygy_4c=r#e#4EX^NUGUc5");
 
-  const url = `${youdaoTranslatURL}/translate_o?smartresult=dict&smartresult=rule`;
+  const url = `${youdaoTranslatURL}/translate?smartresult=dict&smartresult=rule`;
   const data = {
     salt,
     sign,


### PR DESCRIPTION
最近在调用翻译的时候会收到报错 `Youdao Translate Error: 50`，虽然可以正常得到结果，但是有报错看起来还是不太舒服。

<img width="750" alt="image" src="https://github.com/user-attachments/assets/b31e470a-5fc7-48a5-a371-9fdf6fa0422e" />

搜索了下貌似是个反扒相关的报错，根据 https://fishc.com.cn/forum.php?mod=redirect&goto=findpost&ptid=106575&pid=3248429 给出的方案修复。我也不清楚这是否是最佳的解决方案。如果有更好的解决方案的话还请指出。

注意！因为不熟悉 Raycast 插件开发所以 **没有验证过该 PR 是否可用**，有劳大佬验证一下是否解决了问题。

感谢大佬及这个插件。