### PR TITLE
fix: include Norwegian ("no") in language preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,10 @@
           "value": "my"
         },
         {
+          "title": "Norwegian",
+          "value": "no"
+        },
+        {
           "title": "Georgian",
           "value": "ka"
         },
@@ -496,6 +500,10 @@
         {
           "title": "Burmese",
           "value": "my"
+        },
+        {
+          "title": "Norwegian",
+          "value": "no"
         },
         {
           "title": "Georgian",


### PR DESCRIPTION
Fixes: https://github.com/raycast/extensions/issues/24689

This PR adds Norwegian as an option in the language preferences:

```
{
  "title": "Norwegian",
  "value": "no"
}
```

If needed, should we review the other languages to ensure all supported target languages, at least those listed in the README, are included in the preferences?