### PR TITLE
fix(openai): support `max_completion_tokens` for reasoning models

### DIFF
--- a/package.json
+++ b/package.json
@@ -758,6 +758,15 @@
       "default": "gpt-4o-mini"
     },
     {
+      "title": "Force max_completion_tokens",
+      "name": "forceMaxCompletionTokens",
+      "type": "checkbox",
+      "label": "Always use max_completion_tokens",
+      "required": false,
+      "description": "Force using max_completion_tokens instead of max_tokens. Useful for reasoning models (e.g., o1, o3, gpt-5) or providers that require it. May break compatibility with some OpenAI-compatible APIs.",
+      "default": false
+    },
+    {
       "title": "Gemini API Key",
       "name": "geminiAPIKey",
       "type": "password",

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -66,6 +66,7 @@ export interface MyPreferences {
   openAIAPIKey: string;
   openAIAPIURL: string;
   openAIModel: string;
+  forceMaxCompletionTokens: boolean;
 
   enableGeminiTranslate: boolean;
   geminiAPIKey: string;
@@ -103,6 +104,7 @@ export class AppKeyStore {
   static openAIAPIKey = myPreferences.openAIAPIKey.trim();
   static openAIEndpoint = myPreferences.openAIAPIURL.trim() || "https://api.openai.com/v1/chat/completions";
   static openAIModel = myPreferences.openAIModel.trim() || "gpt-3.5-turbo";
+  static forceMaxCompletionTokens = myPreferences.forceMaxCompletionTokens;
 
   static geminiAPIKey = myPreferences.geminiAPIKey.trim();
   static geminiEndpoint = myPreferences.geminiAPIURL.trim() || "https://generativelanguage.googleapis.com";

--- a/src/translation/openAI/chat.ts
+++ b/src/translation/openAI/chat.ts
@@ -21,6 +21,29 @@ const timeout = setTimeout(() => {
   controller.abort();
 }, networkTimeout); // set timeout to 15s.
 
+const REASONING_MODEL_PATTERN = /^(o1|o3|gpt-5)/i;
+
+const KNOWN_ENDPOINTS = ["https://api.openai.com/"];
+
+const DEFAULT_MAX_TOKENS = 2000;
+
+type MaxTokensParams = { max_tokens: number };
+type MaxCompletionTokensParams = { max_completion_tokens: number };
+type TokenLimitParams = MaxTokensParams | MaxCompletionTokensParams;
+
+/**
+ * Determines the appropriate token limit parameter based on endpoint and model.
+ */
+function getTokenLimitParams(endpoint: string, model: string): TokenLimitParams {
+  const isKnownEndpoint = KNOWN_ENDPOINTS.includes(endpoint);
+  const isReasoningModel = REASONING_MODEL_PATTERN.test(model);
+  const forceMaxCompletionTokens = AppKeyStore.forceMaxCompletionTokens;
+  const useMaxCompletionTokens = forceMaxCompletionTokens || (isKnownEndpoint && isReasoningModel);
+
+  if (useMaxCompletionTokens) return { max_completion_tokens: DEFAULT_MAX_TOKENS };
+  return { max_tokens: DEFAULT_MAX_TOKENS };
+}
+
 export async function requestOpenAIStreamTranslate(queryWordInfo: QueryWordInfo): Promise<QueryTypeResult> {
   console.warn(`---> start request OpenAI`);
 
@@ -95,11 +118,13 @@ export async function requestOpenAIStreamTranslate(queryWordInfo: QueryWordInfo)
     },
   ];
 
+  const tokenLimitParams = getTokenLimitParams(url, AppKeyStore.openAIModel);
+
   const params = {
     model: AppKeyStore.openAIModel,
     messages: message,
     temperature: 0,
-    max_tokens: 2000,
+    ...tokenLimitParams,
     top_p: 1.0,
     frequency_penalty: 1,
     presence_penalty: 1,


### PR DESCRIPTION
Fixes https://github.com/raycast/extensions/issues/26761

### Background

According to the [OpenAI docs](https://help.openai.com/en/articles/5072518-controlling-the-length-of-openai-model-responses#h_930bf1dfa4), reasoning models (e.g. `o1`, `o3`, `gpt-5`) require `max_completion_tokens`, and `max_tokens` is not supported:

Currently, our extension uses `max_tokens` for all models, which leads to incompatibility with reasoning models.

For OpenAI-compatible providers, behavior is inconsistent:

* Some still expect `max_tokens`
* Others follow OpenAI’s newer convention (`max_completion_tokens`)

This creates ambiguity when integrating with different providers.

---

### Changes

* Introduced model-based detection for reasoning models using pattern (From [Dify’s approach](https://github.com/langgenius/dify-official-plugins/blob/12ea13bd9e6af1c15adb9a9f1bf3b57b3f7ea5ff/models/openai_api_compatible/models/llm/llm.py#L438C13-L438C41)):

  ```ts
  /^(o1|o3|gpt-5)/i
  ```

* Added endpoint-aware logic:

  * When using the official OpenAI endpoint (`https://api.openai.com/`)
  * AND the model matches a reasoning model
  * Automatically switch to `max_completion_tokens`

* Added a user-configurable option:

  * `forceMaxCompletionTokens`
  * Allows forcing `max_completion_tokens` regardless of endpoint/model
  * Useful for OpenAI-compatible providers that follow the new convention